### PR TITLE
fix(style): ensure widgetbot doesn't add padding below footers

### DIFF
--- a/src/js/discord.js
+++ b/src/js/discord.js
@@ -18,6 +18,15 @@ function initDiscord() {
             defer: false,
         });
 
+        // Apply CSS position change directly in JavaScript
+        const style = document.createElement('style');
+        style.innerHTML = `
+            widgetbot-crate {
+                position: fixed !important;
+            }
+        `;
+        document.head.appendChild(style);
+
         // get random video game quotes and notify the user on Widgetbot after 7 minutes
         fetchRandomQuote().then(quote => {
             setTimeout(() => {


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Widgetbot can create a small padding below footers, which is often a different color than the footer color. Positioning the widgetbot-crate element seems to help.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
